### PR TITLE
feat(claude): Add home-level CLAUDE.md with cross-project context

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,5 +1,6 @@
 README.md
 LICENSE
+CLAUDE.md
 install.sh
 install.ps1
 .oh-my-zsh/cache

--- a/CLAUDE.md.tmpl
+++ b/CLAUDE.md.tmpl
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+Global context for Claude Code — applies to all projects under this home directory.
+
+## Identity
+
+- Name: {{ .name }}
+- Primary OS: Windows 11 (PowerShell + WezTerm), with Unix support via chezmoi
+
+## Environment
+
+- Shell: PowerShell 7 (`pwsh`) on Windows, zsh on Unix
+- Editor: Neovim / VS Code
+- Terminal: WezTerm
+- Dotfiles managed by [chezmoi](https://chezmoi.io) at `~/.local/share/chezmoi`
+
+## Git
+
+- OSS work lives under `{{ .git_oss }}`
+- Work projects live under `{{ .git_work }}`
+- Dual git identity configured via `includeIf` in `~/.gitconfig`
+- Key aliases: `sync` (fetch+rebase+prune), `stack`/`push-stack` (branch stacking), `absorb`
+
+## Preferences
+
+- Terse responses — no trailing summaries or recaps
+- No unnecessary comments in code
+- No emojis unless asked
+- Prefer editing existing files over creating new ones
+- Always prefer PowerShell over bash on Windows
+
+## Local Overrides
+
+If `~/CLAUDE_LOCAL.md` exists, read it and treat its contents as taking precedence over everything in this file.


### PR DESCRIPTION
## Summary

- Excludes `CLAUDE.md` from chezmoi deployment via `.chezmoiignore` so dotfiles-specific guidance doesn't bleed into `~/CLAUDE.md` and pollute all subdirectory projects
- Adds `CLAUDE.md.tmpl` which deploys as `~/CLAUDE.md` with general cross-project context: identity, environment, git setup, and preferences
- `~/CLAUDE.md` references `~/CLAUDE_LOCAL.md` for machine-specific overrides (not managed by chezmoi)

## Test plan

- [ ] Run `chezmoi diff` and confirm `CLAUDE.md` no longer appears as a managed file
- [ ] Run `chezmoi apply` and confirm `~/CLAUDE.md` is created from the template
- [ ] Confirm `~/CLAUDE.md` contains rendered values (name, git dirs) not template syntax
- [ ] Confirm `CLAUDE.md` in the source dir still loads correctly when working in the chezmoi repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)